### PR TITLE
Bump Julia version 1.6.0 -> 1.6.2

### DIFF
--- a/julia.nix
+++ b/julia.nix
@@ -39,7 +39,7 @@ let
     };
 in {
   julia_16 =
-    makeJulia "1.6.0" "sha256-Rjtx3HDKcJTA4P1tVdEwBRp5AejexetE1gAsV9G9hYU=";
+    makeJulia "1.6.2" "sha256-PrS1d1sN8a049sQJ6YlQGrRFyVvLAasCvWD1vR6CMkA=";
   julia_15 =
     makeJulia "1.5.4" "1icb3rpn2qs6c3rqfb5rzby1pj6h90d9fdi62nnyi4x5s58w7pl0";
   julia_10 =


### PR DESCRIPTION
This *replaces* 1.6.0 with 1.6.2. Maybe it would be preferable to add it as an alternative.