### PR TITLE
Add `poetry` and more or less fix `juliacall` and `PyCall`

### DIFF
--- a/fhs.nix
+++ b/fhs.nix
@@ -42,6 +42,7 @@ let
       which
       texliveScheme
       ncurses
+      poetry
     ] ++ lib.optional enableNode pkgs.nodejs;
 
   graphicalPackages = pkgs:

--- a/module.nix
+++ b/module.nix
@@ -51,6 +51,7 @@ in
             if version-spec.default then [
               (fhsCommand "python3" "python3")
               (fhsCommand "python" "python3")
+              (fhsCommand "poetry" "poetry")
             ] else
               [ ];
           quarto = if version-spec.default then [ (fhsCommand "quarto" "quarto") ] else [];


### PR DESCRIPTION
I've been struggling to get Python and Julia to play nice on NixOS, your project has been very helpful except it doesn't have Poetry, which is what I use to manage my Python environments. This is my first time doing FHS things so if I need to change things let me know. I had to a `poetry` under the standard package because if I didn't it wouldn't work and I don't really understand why. 