### PR TITLE
Add additonal graphics libraries `libdrm` and `mesa`

### DIFF
--- a/fhs.nix
+++ b/fhs.nix
@@ -77,6 +77,7 @@ let
       libselinux
       libuuid
       libxkbcommon
+      mesa # TODO: Use libgbm instead when upstream fixed: https://github.com/NixOS/nixpkgs/issues/218232
       ncurses
       nspr
       nss

--- a/fhs.nix
+++ b/fhs.nix
@@ -68,6 +68,7 @@ let
       gtk3
       libGL
       libcap
+      libdrm
       libgnome-keyring3
       libgpgerror
       libnotify


### PR DESCRIPTION
Issue Solved: Missing libraries when running `Mimi.jl`'s explore function.