### PR TITLE
Clarify julia versioning scheme in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ programs.scientific-fhs = {
   enable = true;
   juliaVersions = [
     {
-      version = "julia_18";
+      version = "1.10.1";
       default = true;
     }
-    { version = "julia_17"; }
-    { version = "julia_16"; }
+    { version = "1.9.3"; }
+    { version = "1.8.3"; }
   ];
   enableNVIDIA = false;
 };


### PR DESCRIPTION
Hey @olynch. I think the versioning in the README might have gone out date with https://github.com/olynch/scientific-fhs/pull/10.  This PR matches what I have locally.