### PR TITLE
Fix Julia 1.10.4, add 1.11.0, 1.11.1

### DIFF
--- a/fhs.nix
+++ b/fhs.nix
@@ -1,7 +1,7 @@
 { lib
 , pkgs
 , enableJulia ? true
-, juliaVersion ? "1.10.1"
+, juliaVersion ? "1.11.1"
 , enableConda ? false
 , enablePython ? false
 , enableQuarto ? true

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       packages.x86_64-linux.scientific-fhs = pkgs.callPackage ./fhs.nix {
         enableNVIDIA = false;
         enableGraphical = true;
-        juliaVersion = "1.10.1";
+        juliaVersion = "1.11.1";
       };
     };
 }

--- a/julia.nix
+++ b/julia.nix
@@ -3,7 +3,7 @@
 let
   versionShas = {
     "1.11.0-rc1" = "sha256-2dfKgQhxhau7ijdcQfc03upuomrvLcQNmUZ/jFx8yNY=";
-    "1.10.4" = "sha256-/pJCWOVdB0QQsTQZXPa4XL6PMH/NBaT90j+JRMWUGnA=";
+    "1.10.4" = "sha256-B59hdXw7W0DSreBSs8xIFvUPfvbfZogldyVis3Rq3/E=";
     "1.10.1" = "sha256-/pJCWOVdB0QQsTQZXPa4XL6PMH/NBaT90j+JRMWUGnA=";
     "1.10.0" = "sha256-pymCB/cvKyeyqxzjkqbqN6+9H77g8fjRkLBU3KuoeP4=";
     "1.10.0-beta2" = "sha256-8aF/WlKYDBZ0Fsvk7aFEGdgY87dphUARVKOlZ4edZHc=";

--- a/julia.nix
+++ b/julia.nix
@@ -2,6 +2,8 @@
 
 let
   versionShas = {
+    "1.11.1" = "sha256-zKjRPcRQfk9ioSkyIpMxPuV08wDU3559swt7QcX4qPM=";
+    "1.11.0" = "sha256-vPgVVT/aLteRBSTIyqGJyOgZGkCnmd2LX77Q2d1riCw=";
     "1.11.0-rc1" = "sha256-2dfKgQhxhau7ijdcQfc03upuomrvLcQNmUZ/jFx8yNY=";
     "1.10.4" = "sha256-B59hdXw7W0DSreBSs8xIFvUPfvbfZogldyVis3Rq3/E=";
     "1.10.1" = "sha256-/pJCWOVdB0QQsTQZXPa4XL6PMH/NBaT90j+JRMWUGnA=";

--- a/module.nix
+++ b/module.nix
@@ -20,7 +20,7 @@ in
         };
       });
       default = [{
-        version = "1.9.3";
+        version = "1.11.1";
         default = true;
       }];
     };


### PR DESCRIPTION
Same as in https://github.com/olynch/scientific-fhs/pull/19 the hash for 1.10.4 should be fixed.
I have also added versions 1.11.0 and 1.11.1.